### PR TITLE
Add support to Prism for the Astro language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "platformatic-oss-website",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/prism": "^1.0.1",
         "@docusaurus/core": "2.0.1",
         "@docusaurus/preset-classic": "2.0.1",
         "@mdx-js/react": "^1.6.22",
@@ -184,6 +185,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-1.0.1.tgz",
+      "integrity": "sha512-HxEFslvbv+cfOs51q/C7aMVFuW3EAGg0d1xXU/0e/QeScDzfrp5Ra4SOb8mV082SgENVjtVvet4zR84t3at4VQ==",
+      "dependencies": {
+        "prismjs": "^1.28.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.12.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -13212,6 +13224,14 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@astrojs/prism": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-1.0.1.tgz",
+      "integrity": "sha512-HxEFslvbv+cfOs51q/C7aMVFuW3EAGg0d1xXU/0e/QeScDzfrp5Ra4SOb8mV082SgENVjtVvet4zR84t3at4VQ==",
+      "requires": {
+        "prismjs": "^1.28.0"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
+    "@astrojs/prism": "1.0.1",
     "@docusaurus/core": "2.0.1",
     "@docusaurus/preset-classic": "2.0.1",
     "@mdx-js/react": "^1.6.22",

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,25 @@
+import siteConfig from '@generated/docusaurus.config';
+
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: {prism},
+  } = siteConfig;
+  const {additionalLanguages} = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  // TODO: This is a hack. This can be done properly if Astro agree to the
+  //       package exposing this entrypoint.
+  require('../../node_modules/@astrojs/prism/dist/plugin.js').addAstro(PrismObject);
+
+  delete globalThis.Prism;
+}


### PR DESCRIPTION
This enables syntax highlighting for `astro` code blocks.

The [@astro/prism](https://www.npmjs.com/package/@astrojs/prism) package is pinned to v1.0.1 as we're importing a module from it that isn't exposed by the package.

`prism-include-languages.js` was generated with:

```bash
npm run swizzle @docusaurus/theme-classic prism-include-languages
```

See: https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages