### PR TITLE
Typescript configs are under the plugins configs

### DIFF
--- a/versioned_docs/version-0.36.0/reference/db/plugin.md
+++ b/versioned_docs/version-0.36.0/reference/db/plugin.md
@@ -113,4 +113,4 @@ export default async function (fastify: FastifyInstance, opts: FastifyPluginOpti
 }
 ```
 
-Note that you need to add the `"typescript": true` configuration to your `platformatic.service.json`.
+Note that you need to add the `"plugins": { "typescript": true }` configuration to your `platformatic.service.json`.


### PR DESCRIPTION
Just make it clear that enabling `typescript` configs are under the `plugins` config