### PR TITLE
Keep only the latest 5 version of documentation

### DIFF
--- a/.github/workflows/rebuild-and-deploy-docs.yml
+++ b/.github/workflows/rebuild-and-deploy-docs.yml
@@ -81,6 +81,10 @@ jobs:
           npx docusaurus docs:version ${{ env.REMOTE_VERSION }}
         env:
           REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
+      - name: Purge old versions
+        if: (!inputs.force && steps.evaluate_versions.outputs.versions-compare == 'true')
+        run: |
+          node ./scripts/purge-old-versions.js
       - name: Build Docusaurus website  
         if: inputs.original_event == 'push_on_main' || inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         run: |
@@ -92,6 +96,8 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: '[automated commit] Bump docs to version ${{ env.REMOTE_VERSION }}'
+          tagging_message: 'v${{ env.REMOTE_VERSION }}'
+
         env: 
           REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ On a unix system:
 
 Deploy happens in Github Actions. Take a look at the workflow in `.github` folder.
 
+## Generate docs for an old Platformatic version
+
+We keep online only the last 5 versions of Platformatic backwards.
+Every time a new version is realeased, this repository is tagged with `vX.Y.Z`
+
+To generate the documentation for a specific version, checkout the related tag and run the development server.
+
 ## Known issues
 
 ### Deleting directories

--- a/scripts/purge-old-versions.js
+++ b/scripts/purge-old-versions.js
@@ -1,0 +1,56 @@
+'use strict'
+const { join } = require('node:path')
+const { readFile, writeFile, readdir, unlink, rmdir, rm } = require('node:fs/promises') 
+const { parseArgs } = require('node:util')
+
+const parseArgsOptions = {
+  'dry-run': {
+    type: 'boolean',
+    default: false
+  },
+  'keep': {
+    type: 'string',
+    default: '5'
+  }
+}
+
+async function main() {
+  const {
+    values
+  } = parseArgs({ options: parseArgsOptions })
+  const versionsToKeep = await purgeVersionsJsonFile(values.keep, values['dry-run'])
+  await purgeDirectories(versionsToKeep, values['dry-run'])
+}
+
+async function purgeVersionsJsonFile(numberOfOldVersionToKeep, dryRun) {
+  const versionsFile = join(__dirname, '..', 'versions.json')
+  const versionsArray = JSON.parse(await readFile(versionsFile, 'utf8'))
+  const newVersions = versionsArray.slice(0, numberOfOldVersionToKeep)
+  if (!dryRun) {
+    await writeFile(versionsFile, JSON.stringify(newVersions, null, 2))
+  } else {
+    console.log(`Would keep only the following versions in versions.json file: ${newVersions.join(', ')}`)
+  }
+  return newVersions
+}
+
+async function purgeDirectories(versionsToKeep = [], dryRun) {
+  const versionsFolder = join(__dirname, '..', 'versioned_docs')
+  const sidebarsFolder = join(__dirname, '..', 'versioned_sidebars')
+  const entries = await readdir(versionsFolder)
+
+  for (const dir of entries) {
+    const flat = versionsToKeep.join('|').replace(/\./g, '\\.')
+    const re = new RegExp(`(${flat})`)
+    if (!dir.match(re)) {
+      if (dryRun) {
+        console.log(`Would delete ${dir} directory`)
+      } else {
+        await rm(join(versionsFolder, dir), { recursive: true })
+        await rm(join(sidebarsFolder, `${dir}-sidebars.json`))
+      }
+    }
+  }
+}
+
+main()


### PR DESCRIPTION
Sice we're running out of memory building docusarius for so many releases we decided to keep only the latest 5 versions of documentation online.

The workflow is changed and runs the `purge-old-versions.js` script before building docusarius.
Also, it adds a tag `vX.Y.Z` to the commit with the updated documentation.

The current commit on `main` (f3fe3eb31a65329a8e0cdbb5957b9b5f57d8da28) will be tagged with _all_ current versions (until 0.38.1) since it contains all of them.

After this PR is approved, I will push all tags on this repo