### PR TITLE
Update quick-start-watt.md

### DIFF
--- a/versioned_docs/version-2.2.1/getting-started/quick-start-watt.md
+++ b/versioned_docs/version-2.2.1/getting-started/quick-start-watt.md
@@ -265,7 +265,7 @@ Finally, let's add `Next` to our composer:
     "services": [{
       "id": "node",
       "proxy": {
-        "path": "/node"
+        "prefix": "/node"
       }
     }, {
       "id": "next"


### PR DESCRIPTION
Update Watt guide proxy specification with prefix and not a path, as this throws an error. The path should be boolean, and for a single service. 