### PR TITLE
fix: change sql-openapi ignoreRoutes bracket

### DIFF
--- a/docs/packages/sql-openapi/ignore.md
+++ b/docs/packages/sql-openapi/ignore.md
@@ -37,12 +37,12 @@ You can also ignore specific auto-generated routes for an entity.
 
 ```js
 app.register(require('@platformatic/sql-openapi'), {
-  ignoreRoutes: {
+  ignoreRoutes: [
     { method: 'GET', path: '/categories' },
     { method: 'GET', path: '/categories/{id}' },
     { method: 'DELETE', path: '/categories/{id}' },
     { method: 'DELETE', path: '/posts/{id}' }
-  }
+  ]
 })
 ```
 


### PR DESCRIPTION
according to [code](https://github.com/platformatic/platformatic/blob/816650c5935e74f6aebabde7f00b6ef19c0b477c/packages/sql-openapi/index.js#L42) align the example to use array of object instead of object
