### PR TITLE
Add storyblok api token to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
     secrets:
       GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
       TARGET_REPO: ${{ secrets.TARGET_REPO }}
+      STORYBLOK_ACCESS_TOKEN: ${{ secrets.STORYBLOK_ACCESS_TOKEN }}
   repository-dispatch:
     if: (github.event_name == 'repository_dispatch' && github.event.action == 'update_docs')
     uses: platformatic/docs/.github/workflows/rebuild-and-deploy-docs.yml@main
@@ -38,6 +39,7 @@ jobs:
     secrets:
       GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
       TARGET_REPO: ${{ secrets.TARGET_REPO }}
+      STORYBLOK_ACCESS_TOKEN: ${{ secrets.STORYBLOK_ACCESS_TOKEN }}
   workflow-dispatch:
     if: (github.event_name == 'workflow_dispatch')
     uses: platformatic/docs/.github/workflows/rebuild-and-deploy-docs.yml@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,3 +48,4 @@ jobs:
     secrets:
       GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
       TARGET_REPO: ${{ secrets.TARGET_REPO }}
+      STORYBLOK_ACCESS_TOKEN: ${{ secrets.STORYBLOK_ACCESS_TOKEN }}

--- a/.github/workflows/rebuild-and-deploy-docs.yml
+++ b/.github/workflows/rebuild-and-deploy-docs.yml
@@ -32,6 +32,8 @@ on:
       TARGET_REPO:
         description: "The repo where Docusaurus is"
         required: true
+      STORYBLOK_ACCESS_TOKEN:
+        description: "Storyblok access token"
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -53,6 +55,7 @@ jobs:
         env:
           TARGET_REPO: ${{ secrets.TARGET_REPO }}
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          STORYBLOK_ACCESS_TOKEN: ${{ secrets.STORYBLOK_ACCESS_TOKEN }}
       - name: Print current versions
         run: |
           echo "Remote versions: ${{ steps.check.outputs.remote-versions }}"

--- a/.github/workflows/rebuild-and-deploy-docs.yml
+++ b/.github/workflows/rebuild-and-deploy-docs.yml
@@ -34,6 +34,7 @@ on:
         required: true
       STORYBLOK_ACCESS_TOKEN:
         description: "Storyblok access token"
+        required: true
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebuild-and-deploy-docs.yml
+++ b/.github/workflows/rebuild-and-deploy-docs.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           TARGET_REPO: ${{ secrets.TARGET_REPO }}
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          STORYBLOK_ACCESS_TOKEN: ${{ secrets.STORYBLOK_ACCESS_TOKEN }}
       - name: Push commit
         if: inputs.original_event == 'push_on_main' || inputs.force || steps.check.outputs.needs-update == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Not sure why it was working until now, but this token seems to be needed to build the docs