### PR TITLE
Update navbar: logo links to platformatic.dev, remove Community and For Teams

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -181,7 +181,9 @@ const config = {
       logo: {
         alt: 'Platformatic Logo',
         src: 'img/platformatic-logo.svg',
-        srcDark: 'img/platformatic-logo.svg'
+        srcDark: 'img/platformatic-logo.svg',
+        href: 'https://platformatic.dev',
+        target: '_self'
       },
       items: [
         {
@@ -201,22 +203,6 @@ const config = {
           docId: 'reference',
           position: 'left',
           label: 'Reference'
-        },
-        {
-          type: 'dropdown',
-          position: 'left',
-          label: 'Community',
-          items: [
-            {
-              href: 'https://platformatichq.com/events',
-              label: 'Events'
-            }
-          ]
-        },
-        {
-          href: 'https://platformatichq.com',
-          label: 'For Teams',
-          position: 'left'
         },
         {
           href: 'https://blog.platformatic.dev',


### PR DESCRIPTION
## Summary
- Make the navbar Platformatic logo link to https://platformatic.dev (same tab)
- Remove the **Community** dropdown and the **For Teams** navbar entries

Fixes https://github.com/platformatic/docs/issues/206

🤖 Generated with [Claude Code](https://claude.com/claude-code)